### PR TITLE
chore(package)!: add type module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-nest",
   "version": "0.1.10",
+  "type": "module",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
As your package is exposing an esm module

This change solve build errors of type

```sh
node_modules/react-nest/dist/react-nest.es.js:1
import require$$0, { Fragment, Children, isValidElement, cloneElement } from "react";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1176:20)
    at Module._compile (node:internal/modules/cjs/loader:1218:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
```

---

BREAKING CHANGE: Might break builds with old bundlers.